### PR TITLE
New bootstrap

### DIFF
--- a/ingestion_program/systematics.py
+++ b/ingestion_program/systematics.py
@@ -611,7 +611,9 @@ def get_bootstrapped_dataset(
             random_state = np.random.RandomState(seed=Seed)
             new_weights = random_state.poisson(bkg_norm[key] * weights)
         
-        temp_data = test_set[key]["weights"] = new_weights
+        test_set[key]["weights"] = new_weights
+
+        temp_data = test_set[key][new_weights > 0].copy()
 
         pseudo_data.append(temp_data)
 

--- a/ingestion_program/systematics.py
+++ b/ingestion_program/systematics.py
@@ -610,6 +610,8 @@ def get_bootstrapped_dataset(
         if poisson:
             random_state = np.random.RandomState(seed=Seed)
             new_weights = random_state.poisson(bkg_norm[key] * weights)
+        else:
+            new_weights = bkg_norm[key] * weights
         
         test_set[key]["weights"] = new_weights
 


### PR DESCRIPTION
The bootstrap strategy has been changed to the more tried and test Poisson bootstrap which works on weighted data sets. 

The test data will still be divided into 4 based [ztautau, ttbar, diboson and higgs] but now it will have an extra field called weights which will set be based on the cross-sections of the individual process that make it up. 

RC