### PR TITLE
patch to fix systematics

### DIFF
--- a/ingestion_program/systematics.py
+++ b/ingestion_program/systematics.py
@@ -644,7 +644,7 @@ def get_bootstrapped_dataset(
 
         temp_data = test_set[key][new_weights > 0]
 
-        temp_data["weights"] = new_weights[new_weights > 0]
+        temp_data.loc[:, "weights"] = new_weights[new_weights > 0]
 
         pseudo_data.append(temp_data)
 


### PR DESCRIPTION
Fixing issue with warning in systematics which @SaschaDief brought up before

The issue was SettingWithCopyWarning it was earlier suppressed using warning.  `warnings.filterwarnings("ignore")`

This is a patch to avoid this warning Entirely

RC