### PR TITLE
fix: added initial seed to logger and use initial seed on random mu. 

### DIFF
--- a/ingestion_program/ingestion.py
+++ b/ingestion_program/ingestion.py
@@ -155,7 +155,7 @@ class Ingestion:
         Args:
             test_settings (dict): The test settings.
         """
-        logger.info("Calling predict method of submitted model")
+        logger.info("Calling predict method of submitted model with seed: %s", initial_seed)
 
         dict_systematics = test_settings["systematics"]
         num_pseudo_experiments = test_settings["num_pseudo_experiments"]

--- a/ingestion_program/ingestion_parallel.py
+++ b/ingestion_program/ingestion_parallel.py
@@ -396,7 +396,7 @@ class Ingestion:
         Args:
             test_settings (dict): The test settings.
         """
-        logger.info("Calling predict method of submitted model")
+        logger.info("Calling predict method of submitted model with seed: %s", initial_seed)
 
         num_pseudo_experiments = test_settings["num_pseudo_experiments"]
         num_of_sets = test_settings["num_of_sets"]

--- a/ingestion_program/run_ingestion.py
+++ b/ingestion_program/run_ingestion.py
@@ -166,8 +166,9 @@ if __name__ == "__main__":
     data.load_test_set()
     
     if args.use_random_mus:
+        random_state = np.random.RandomState(args.random_seed)
         test_settings["ground_truth_mus"] = (
-            np.random.uniform(0.1, 3, test_settings["num_of_sets"])
+            random_state.uniform(0.1, 3, test_settings["num_of_sets"])
         ).tolist()
         test_settings["random_mu"] = True
         random_settings_file = os.path.join(output_dir, "test_settings.json")


### PR DESCRIPTION
Added initial seed to logger and use initial seed on random mu. This Enable us to rerun the submission in another system or locally by taking the seed from codabench logfile. 

Ragansu Chakkappai