### PR TITLE
Update load_ingestion_results in score.py to load files correctly

### DIFF
--- a/scoring_program/score.py
+++ b/scoring_program/score.py
@@ -1,16 +1,16 @@
 # ------------------------------------------
 # Imports
 # ------------------------------------------
-import os
-import numpy as np
-import json
-from datetime import datetime as dt
-import matplotlib.pyplot as plt
-
-import sys
-import io
 import base64
+import io
+import json
 import logging
+import os
+import sys
+from datetime import datetime as dt
+
+import matplotlib.pyplot as plt
+import numpy as np
 
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 
@@ -105,14 +105,19 @@ class Scoring:
             prediction_dir (str, optional): location of the predictions. Defaults to "./".
             score_dir (str, optional): location of the scores. Defaults to "./".
         """
-        self.ingestion_results = []
+        ingestion_results_with_set_index = []
         # loop over sets (1 set = 1 value of mu)
-        for file in sorted(os.listdir(prediction_dir)):
-            logger.debug(f"Reading ingestion results from {file}")
+        for file in os.listdir(prediction_dir):
             if file.startswith("result_"):
+                set_index = int(file.split("_")[1].split(".")[0]) # file format: result_{set_index}.json
                 results_file = os.path.join(prediction_dir, file)
                 with open(results_file) as f:
-                    self.ingestion_results.append(json.load(f))
+                    ingestion_results_with_set_index.append({
+                        "set_index": set_index,
+                        "results": json.load(f)
+                    })
+        ingestion_results_with_set_index = sorted(ingestion_results_with_set_index, key=lambda x: x["set_index"])
+        self.ingestion_results = [x["results"] for x in ingestion_results_with_set_index]
 
         self.score_file = os.path.join(score_dir, "scores.json")
         self.html_file = os.path.join(score_dir, "detailed_results.html")


### PR DESCRIPTION
### Background
In the current implementation, when loading ingestion result files (e.g., result_0.json), there is a bug where the files are randomly reordered. 
This issue occurs on both Codabench and local environments.
![image](https://github.com/user-attachments/assets/39c0176a-28cd-4534-9a23-c45d159150c1)
As a result, inference outcomes appear as shown above. 
With this pull request's fix, scoring was successfully performed locally.

### Changes
The root cause was identified in the load_ingestion_results function within the score.py file. 
The result files were being loaded based on the order of os.listdir, which did not work as intended, leading to a random order. 

To address this, I extracted set_index from each filename and used it to sort the files, allowing for loading in the correct order.
`set_index = int(file.split("_")[1].split(".")[0]) # file format: result_{set_index}.json`