### PR TITLE
Fixed python version to `3.12.8` to fix tensorflow installation

### DIFF
--- a/.github/workflows/competition_pipeline_test.yml
+++ b/.github/workflows/competition_pipeline_test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.12.8'
 
     # Step 3: Install dependencies
     - name: Install dependencies


### PR DESCRIPTION
The workflow for complete pipeline test was failing because the python version 3.13.x was not compatible with the tensorflow version. I have fixed the python version to fix this problem