### PR TITLE
Terms and Prize page updates

### DIFF
--- a/pages/prizes.md
+++ b/pages/prizes.md
@@ -11,6 +11,6 @@ Eligibility is determined by the Terms and Conditions that all participants must
 
 In addition to monetary prizes, a jury will evaluate models for which a short write-up will have been submitted. The models will be evaluated in terms of score, practicality, frugality in terms of resources and novelty. 
 
-The special jury prizes will be funded invitations to NeurIPS 2024, to talk during the dedicated session (Saturday 14th Dec) of the competitions workshop or in a dedicated workshop at CERN, Geneva, Switzerland.
+The special jury prizes will be funded invitations to NeurIPS 2024, to talk during the dedicated session (Saturday 14th Dec) of the competitions workshop or in a dedicated workshop at CERN, Geneva, Switzerland (Monday, May 19, 2025 - https://indico.cern.ch/event/1523250/).
 
 NOTE: A single user or team will only be awarded one prize.

--- a/pages/prizes.md
+++ b/pages/prizes.md
@@ -12,3 +12,5 @@ Eligibility is determined by the Terms and Conditions that all participants must
 In addition to monetary prizes, a jury will evaluate models for which a short write-up will have been submitted. The models will be evaluated in terms of score, practicality, frugality in terms of resources and novelty. 
 
 The special jury prizes will be funded invitations to NeurIPS 2024, to talk during the dedicated session (Saturday 14th Dec) of the competitions workshop or in a dedicated workshop at CERN, Geneva, Switzerland.
+
+NOTE: A single user or team will only be awarded one prize.

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -23,7 +23,7 @@ To ensure proper representation and verification of your affiliation with an org
 
 If you are interested in participating as a team, please read the following terms. To register your team, contact us by sending an email to fair-universe@lbl.gov.
 
-1. A team can consist of 2-5 members. All team members must be declared in advance, including their names, emails, and affiliations.
+1. A team can consist of 2-10 members. All team members must be declared in advance, including their names, emails, and affiliations.
 2. Each team must designate one member as the team leader, who will be responsible for communication and submissions.
 3. The team leader must create a Codabench account using their email, and all submissions should be made through this account only.
 4. Multiple accounts for a single team are not allowed. Any team found using multiple accounts will be disqualified.


### PR DESCRIPTION
### Terms page
Allowed max number of members in a team updated from 5 to 10

### Prize page
- This note is added `NOTE: A single user or team will only be awarded one prize.`
- CERN workshop date and link added